### PR TITLE
Migrate to netstandard2.0

### DIFF
--- a/645a1e2b-a9f4-459e-8d5e-a517e430b274.cake
+++ b/645a1e2b-a9f4-459e-8d5e-a517e430b274.cake
@@ -1,1 +1,0 @@
-#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2018.1.2

--- a/645a1e2b-a9f4-459e-8d5e-a517e430b274.cake
+++ b/645a1e2b-a9f4-459e-8d5e-a517e430b274.cake
@@ -1,0 +1,1 @@
+#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2018.1.2

--- a/docs-prep.cake
+++ b/docs-prep.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.FileHelpers&version=2.0.0
+#addin nuget:?package=Cake.FileHelpers&version=3.1.0
 
 Task("Copy-Readme-For-Docs")
     .WithCriteria(() => FileExists("README.md"))

--- a/nuspec/nuget/Cake.Graph.nuspec
+++ b/nuspec/nuget/Cake.Graph.nuspec
@@ -14,7 +14,7 @@
     <tags>Cake Script Build Graph Nodes Dependencies Tasks</tags>
   </metadata>
   <files>
-    <file src="net46\Cake.Graph.dll" target="lib\net46" />
-    <file src="net46\Cake.Graph.pdb" target="lib\net46" />
+    <file src="netstandard2.0\Cake.Graph.dll" target="lib\netstandard2.0" />
+    <file src="netstandard2.0\Cake.Graph.pdb" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/src/Cake.Graph.Tests/Cake.Graph.Tests.csproj
+++ b/src/Cake.Graph.Tests/Cake.Graph.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -13,48 +13,34 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net46|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.0|AnyCPU'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
-    <PackageReference Include="AutoFixture" version="4.0.1" />
-    <PackageReference Include="Cake.Core" version="0.28.0" PrivateAssets="All" />
-    <PackageReference Include="Castle.Core" version="4.2.1" />
-    <PackageReference Include="Microsoft.AspNet.Razor" version="3.2.3" />
-    <PackageReference Include="Moq" version="4.8.1" />
-    <PackageReference Include="RazorEngine" version="3.10.0" />
-    <PackageReference Include="Shouldly" version="3.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" version="4.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" version="15.6.2" />
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.0.1" />
+    <PackageReference Include="Cake.Core" Version="0.30.0" PrivateAssets="All" />
+    <PackageReference Include="Castle.Core" Version="4.2.1" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.3" />
+    <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="RazorEngine" Version="3.10.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="xunit" version="2.3.1" />
-    <PackageReference Include="xunit.runner.console" version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" version="2.3.1" />
-    <PackageReference Include="xunit.abstractions" version="2.0.1" />
-    <PackageReference Include="xunit.analyzers" version="0.8.0" />
-    <PackageReference Include="xunit.assert" version="2.3.1" />
-    <PackageReference Include="xunit.core" version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.core" version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.execution" version="2.3.1" />
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.8.0" />
+    <PackageReference Include="xunit.assert" Version="2.3.1" />
+    <PackageReference Include="xunit.core" Version="2.3.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data\index.cshtml" />

--- a/src/Cake.Graph.Tests/GraphGeneratorTests.cs
+++ b/src/Cake.Graph.Tests/GraphGeneratorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Graph.Generators;
 using Shouldly;
@@ -25,11 +26,11 @@ namespace Cake.Graph.Tests
         [InlineData(typeof(MermaidHtmlGenerator), TestHelpers.TaskCMermaidPattern)]
         [InlineData(typeof(CytoscapeHtmlGenerator), TestHelpers.TaskCCytoscapePattern)]
         [InlineData(typeof(CytoscapeWyamGenerator), TestHelpers.TaskCCytoscapePattern)]
-        public void Serializes_Tasks_With_Dependencies_Correctly(Type generatorType, string expectedResult)
+        public async Task Serializes_Tasks_With_Dependencies_Correctly(Type generatorType, string expectedResult)
         {
             var mockContext = TestHelpers.GetMockCakeContext();
             var graphGenerator = (ITaskGraphGenerator)Activator.CreateInstance(generatorType);
-            var result = graphGenerator.Serialize(mockContext.Object, taskC, tasks);
+            var result = await graphGenerator.SerializeAsync(mockContext.Object, taskC, tasks);
             result.ShouldMatch(expectedResult);
         }
 

--- a/src/Cake.Graph.Tests/GraphRunnerTests.cs
+++ b/src/Cake.Graph.Tests/GraphRunnerTests.cs
@@ -18,7 +18,7 @@ namespace Cake.Graph.Tests
             var tasks = TestHelpers.CreateTasksWithDependencies();
 
             var emptyGenerator = TestHelpers.GetEmptyTaskGraphGenerator();
-            cakeContext.Object.Graph(tasks).Deploy(s => s
+            cakeContext.Object.Graph(tasks).DeployAsync(s => s
                 .WithCustomGenerator(emptyGenerator)
                 .SetOutputPath(outputPath)
             );

--- a/src/Cake.Graph.Tests/GraphTemplateManagerTests.cs
+++ b/src/Cake.Graph.Tests/GraphTemplateManagerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using Cake.Graph.Templates;
 using Shouldly;
 using Xunit;
@@ -16,12 +17,12 @@ namespace Cake.Graph.Tests
             });
             
         [Fact]
-        public void Manager_Parses_Razor_Template()
+        public async Task Manager_Parses_Razor_Template()
         {
             const string test = "test";
             var graphTemplateManager = new GraphTemplateManager(graphTemplateRepository);
-            var result = graphTemplateManager.ParseTemplate(TemplateTypes.Cytoscape, test);
-            result = graphTemplateManager.ParseTemplate(TemplateTypes.Cytoscape, test);
+            var result = await graphTemplateManager.ParseTemplateAsync(TemplateTypes.Cytoscape, test);
+            result = await graphTemplateManager.ParseTemplateAsync(TemplateTypes.Cytoscape, test);
 
             result.ShouldBe(GraphTemplateRepositoryTests.TestFileContent.Replace("@Model", test));
         }

--- a/src/Cake.Graph.Tests/TestHelpers.cs
+++ b/src/Cake.Graph.Tests/TestHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Graph.Generators;
@@ -24,9 +25,9 @@ namespace Cake.Graph.Tests
             mockTaskGraphGenerator
                 .Setup(x => x.Extension)
                 .Returns("test");
-            mockTaskGraphGenerator.Setup(x => x.Serialize(It.IsAny<ICakeContext>(), It.IsAny<ICakeTaskInfo>(),
+            mockTaskGraphGenerator.Setup(x => x.SerializeAsync(It.IsAny<ICakeContext>(), It.IsAny<ICakeTaskInfo>(),
                     It.IsAny<IReadOnlyList<ICakeTaskInfo>>()))
-                .Returns((ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks) => "");
+                .Returns((ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks) => Task.FromResult(""));
 
             return mockTaskGraphGenerator.Object;
         }

--- a/src/Cake.Graph/Cake.Graph.csproj
+++ b/src/Cake.Graph/Cake.Graph.csproj
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -13,7 +14,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Cake.Graph.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net46|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
@@ -27,24 +28,12 @@
     <EmbeddedResource Include="Content\cytoscapewyam.cshtml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" version="0.28.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" version="5.2.3" />
-    <PackageReference Include="Microsoft.AspNet.Razor" version="3.2.3" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" version="3.2.3" />
-    <PackageReference Include="Microsoft.Web.Infrastructure" version="1.0.0.0" />
-    <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
-    <PackageReference Include="RazorEngine" version="3.10.0" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Cake.Core" Version="0.30.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.3" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.3" />
+    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Graph/Generators/CytoscapeGraphGenerator.cs
+++ b/src/Cake.Graph/Generators/CytoscapeGraphGenerator.cs
@@ -19,12 +19,12 @@ namespace Cake.Graph.Generators
         /// <param name="task"></param>
         /// <param name="tasks"></param>
         /// <returns></returns>
-        public async Task<string> SerializeAsync(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
+        public Task<string> SerializeAsync(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
         {
             TaskGraphGeneratorHelpers.ValidateParameters(context, task, tasks);
 
             var nodes = GetTaskGraphNodes(context, task, tasks);
-            return JsonConvert.SerializeObject(nodes);
+            return Task.FromResult(JsonConvert.SerializeObject(nodes));
         }
 
         /// <summary>

--- a/src/Cake.Graph/Generators/CytoscapeGraphGenerator.cs
+++ b/src/Cake.Graph/Generators/CytoscapeGraphGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Newtonsoft.Json;
@@ -18,7 +19,7 @@ namespace Cake.Graph.Generators
         /// <param name="task"></param>
         /// <param name="tasks"></param>
         /// <returns></returns>
-        public string Serialize(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
+        public async Task<string> SerializeAsync(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
         {
             TaskGraphGeneratorHelpers.ValidateParameters(context, task, tasks);
 

--- a/src/Cake.Graph/Generators/CytoscapeHtmlGenerator.cs
+++ b/src/Cake.Graph/Generators/CytoscapeHtmlGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Graph.Models;
 using Cake.Graph.Templates;
@@ -48,11 +49,11 @@ namespace Cake.Graph.Generators
         protected TemplateTypes templateType = TemplateTypes.Cytoscape;
 
         /// <inheritdoc />
-        public string Serialize(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
+        public async Task<string> SerializeAsync(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
         {
-            var graph = graphGenerator.Serialize(context, task, tasks);
+            var graph = await graphGenerator.SerializeAsync(context, task, tasks);
             var model = new GraphHtmlModel(task.Name, CytoscapeJsSource, graph);
-            var html = graphTemplateManager.ParseTemplate(templateType, model);
+            var html = await graphTemplateManager.ParseTemplateAsync(templateType, model);
             return html;
         }
     }

--- a/src/Cake.Graph/Generators/ITaskGraphGenerator.cs
+++ b/src/Cake.Graph/Generators/ITaskGraphGenerator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Cake.Core;
 
 namespace Cake.Graph.Generators
@@ -15,7 +16,7 @@ namespace Cake.Graph.Generators
         /// <param name="task"></param>
         /// <param name="tasks"></param>
         /// <returns></returns>
-        string Serialize(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks);
+        Task<string> SerializeAsync(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks);
         /// <summary>
         /// The file extension to use for this type of graph file
         /// </summary>

--- a/src/Cake.Graph/Generators/MermaidGraphGenerator.cs
+++ b/src/Cake.Graph/Generators/MermaidGraphGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 
@@ -24,7 +25,7 @@ namespace Cake.Graph.Generators
         /// <param name="task"></param>
         /// <param name="tasks"></param>
         /// <returns></returns>
-        public string Serialize(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
+        public async Task<string> SerializeAsync(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
         {
             TaskGraphGeneratorHelpers.ValidateParameters(context, task, tasks);
 

--- a/src/Cake.Graph/Generators/MermaidHtmlGenerator.cs
+++ b/src/Cake.Graph/Generators/MermaidHtmlGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Graph.Models;
 using Cake.Graph.Templates;
@@ -45,11 +46,11 @@ namespace Cake.Graph.Generators
         /// <param name="task"></param>
         /// <param name="tasks"></param>
         /// <returns></returns>
-        public string Serialize(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
+        public async Task<string> SerializeAsync(ICakeContext context, ICakeTaskInfo task, IReadOnlyList<ICakeTaskInfo> tasks)
         {
-            var graph = graphGenerator.Serialize(context, task, tasks);
+            var graph = await graphGenerator.SerializeAsync(context, task, tasks);
             var model = new GraphHtmlModel(task.Name, MermaidJsSource, graph);
-            var html = graphTemplateManager.ParseTemplate(TemplateTypes.Mermaid, model);
+            var html = await graphTemplateManager.ParseTemplateAsync(TemplateTypes.Mermaid, model);
             return html;
         }
     }

--- a/src/Cake.Graph/GraphRunner.cs
+++ b/src/Cake.Graph/GraphRunner.cs
@@ -43,6 +43,13 @@ namespace Cake.Graph
         /// <summary>
         /// Generate the node set files and deploy the web content files
         /// </summary>
+        /// <param name="configure"></param>
+        public GraphRunner Deploy(Action<GraphSettings> configure = null) =>
+            DeployAsync(configure).GetAwaiter().GetResult();
+        
+        /// <summary>
+        /// Generate the node set files and deploy the web content files
+        /// </summary>
         /// <param name="settings"></param>
         public async Task<GraphRunner> DeployAsync(GraphSettings settings)
         {
@@ -69,5 +76,11 @@ namespace Cake.Graph
 
             return this;
         }
+
+        /// <summary>
+        /// Generate the node set files and deploy the web content files
+        /// </summary>
+        /// <param name="settings"></param>
+        public GraphRunner Deploy(GraphSettings settings) => DeployAsync(settings).GetAwaiter().GetResult();
     }
 }

--- a/src/Cake.Graph/GraphTemplate.cs
+++ b/src/Cake.Graph/GraphTemplate.cs
@@ -1,4 +1,7 @@
-using RazorEngine.Templating;
+//using RazorEngine.Templating;
+
+using System.Threading.Tasks;
+using RazorLight;
 
 namespace Cake.Graph
 {
@@ -7,14 +10,16 @@ namespace Cake.Graph
     /// Template for processing web files before saving
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class GraphTemplate<T> : TemplateBase<T>
+    public class GraphTemplate<T> : TemplatePage<T>
     {
         /// <summary>
         /// Model to use in Template
         /// </summary>
-        public new T Model
+        public new T Model => base.Model;
+
+        public override Task ExecuteAsync()
         {
-            get => base.Model;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Cake.Graph/Templates/GraphTemplateManager.cs
+++ b/src/Cake.Graph/Templates/GraphTemplateManager.cs
@@ -63,7 +63,7 @@ namespace Cake.Graph.Templates
 
         private async Task<string> ParseAndCacheRazorTemplateAsync<T>(string templateName, string razorTemplate, T model)
         {
-            var htmlFileOutput = await Engine.CompileRenderAsync(templateName, razorTemplate, model);// RenderTemplateAsync(razorTemplate, model); Razor.RunCompile(razorTemplate, templateName, typeof(T), model);
+            var htmlFileOutput = await Engine.CompileRenderAsync(templateName, razorTemplate, model);
             return htmlFileOutput;
         }
     }

--- a/src/Cake.Graph/Templates/GraphTemplateManager.cs
+++ b/src/Cake.Graph/Templates/GraphTemplateManager.cs
@@ -1,7 +1,6 @@
 using System;
-using RazorEngine;
-using RazorEngine.Configuration;
-using RazorEngine.Templating;
+using System.Threading.Tasks;
+using RazorLight;
 
 namespace Cake.Graph.Templates
 {
@@ -10,17 +9,8 @@ namespace Cake.Graph.Templates
     /// </summary>
     public class GraphTemplateManager : IGraphTemplateManager
     {
-        private static readonly ITemplateServiceConfiguration razorTemplateServiceConfig = new TemplateServiceConfiguration
-        {
-            DisableTempFileLocking = true, // loads the files in-memory (gives the templates full-trust permissions)
-            CachingProvider = new DefaultCachingProvider(t => { }) //disables the warnings
-        };
-
-        static GraphTemplateManager()
-        {
-            Engine.Razor = RazorEngineService.Create(razorTemplateServiceConfig);
-        }
-
+        private RazorLightEngine Engine { get; }
+        
         private readonly IGraphTemplateRepository graphTemplateRepository;
 
         /// <summary>
@@ -35,6 +25,10 @@ namespace Cake.Graph.Templates
         public GraphTemplateManager(IGraphTemplateRepository graphTemplateRepository)
         {
             this.graphTemplateRepository = graphTemplateRepository ?? throw new ArgumentNullException(nameof(graphTemplateRepository));
+
+            Engine = new RazorLightEngineBuilder()
+                .UseMemoryCachingProvider()
+                .Build();
         }
 
         /// <summary>
@@ -45,35 +39,32 @@ namespace Cake.Graph.Templates
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public string ParseTemplate<T>(TemplateTypes templateTypeKey, T model)
+        public async Task<string> ParseTemplateAsync<T>(TemplateTypes templateTypeKey, T model)
         {
             if (!graphTemplateRepository.TemplateResourcePaths.TryGetValue(templateTypeKey, out var templateResourcePath))
                 throw new ArgumentOutOfRangeException(nameof(templateTypeKey));
 
-            var result = ParseRazorTemplateFromResource(templateResourcePath, model);
+            var result = await ParseRazorTemplateFromResourceAsync(templateResourcePath, model);
             return result;
         }
 
-        private string ParseRazorTemplateFromResource<T>(string resourcePath, T model)
+        private async Task<string> ParseRazorTemplateFromResourceAsync<T>(string resourcePath, T model)
         {
-            var cached = Engine.Razor.IsTemplateCached(resourcePath, typeof(T));
-            if (cached)
-                return ParseCachedRazorTemplate(resourcePath, model);
+            if (Engine.TemplateCache.Contains(resourcePath))
+            {
+                var template = Engine.TemplateCache.RetrieveTemplate(resourcePath).Template.TemplatePageFactory.Invoke();
+                return await Engine.RenderTemplateAsync(template, model);
+            }
 
             var razorTemplate = graphTemplateRepository.ReadResourceToString(resourcePath);
-            var htmlFileOutput = ParseAndCacheRazorTemplate(resourcePath, razorTemplate, model);
+            var htmlFileOutput = await ParseAndCacheRazorTemplateAsync(resourcePath, razorTemplate, model);
             return htmlFileOutput;
         }
 
-        private string ParseAndCacheRazorTemplate<T>(string templateName, string razorTemplate, T model)
+        private async Task<string> ParseAndCacheRazorTemplateAsync<T>(string templateName, string razorTemplate, T model)
         {
-            var htmlFileOutput = Engine.Razor.RunCompile(razorTemplate, templateName, typeof(T), model);
+            var htmlFileOutput = await Engine.CompileRenderAsync(templateName, razorTemplate, model);// RenderTemplateAsync(razorTemplate, model); Razor.RunCompile(razorTemplate, templateName, typeof(T), model);
             return htmlFileOutput;
-        }
-
-        private string ParseCachedRazorTemplate<T>(string resourcePath, T model)
-        {
-            return Engine.Razor.Run(resourcePath, typeof(T), model);
         }
     }
 }

--- a/src/Cake.Graph/Templates/IGraphTemplateManager.cs
+++ b/src/Cake.Graph/Templates/IGraphTemplateManager.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Cake.Graph.Templates
 {
     /// <summary>
@@ -12,6 +14,6 @@ namespace Cake.Graph.Templates
         /// <param name="model"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        string ParseTemplate<T>(TemplateTypes templateTypeKey, T model);
+        Task<string> ParseTemplateAsync<T>(TemplateTypes templateTypeKey, T model);
     }
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.25.0" />
+    <package id="Cake" version="0.28.0" />
 </packages>


### PR DESCRIPTION
For #16 
Some tricky cases:
1. RazorEngine isn't compatible with netstandard. Replate with RazorLight nuget package
2. GraphRunner has async interface due to async-only interface in RazorLight engine. It's a breaking change. For backward compatibility, was added non-async methods, which are called async methods with `GetAwaiter().GetResult()`. Such methods can be marked as Obsolete