### PR TITLE
Build with Cake 0.30.0

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.28.0" />
+    <package id="Cake" version="0.30.0" />
 </packages>


### PR DESCRIPTION
Build with Cake 0.30.0 to avoid long addin restore times for signed packages